### PR TITLE
[codex] Add TinyJuice coverage tests

### DIFF
--- a/src/compressors/generic.rs
+++ b/src/compressors/generic.rs
@@ -35,3 +35,68 @@ impl Compressor for GenericCompressor {
         compress_command_fallback(input, opts)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ContentHint, ContentKind};
+
+    fn input<'a>(
+        content: &'a str,
+        hint: &'a ContentHint,
+        command: Option<String>,
+        argv: Option<Vec<String>>,
+    ) -> CompressInput<'a> {
+        CompressInput {
+            content,
+            kind: ContentKind::PlainText,
+            hint,
+            exit_code: Some(0),
+            command,
+            argv,
+            original_bytes: content.len(),
+        }
+    }
+
+    #[tokio::test]
+    async fn declines_domain_payload_without_command_context() {
+        let hint = ContentHint::default();
+        let opts = CompressOptions::default();
+        let compressor = GenericCompressor;
+
+        let output = compressor
+            .compress(
+                &input("line\n".repeat(100).as_str(), &hint, None, None),
+                &opts,
+            )
+            .await;
+
+        assert!(output.is_none());
+    }
+
+    #[tokio::test]
+    async fn runs_fallback_for_command_context() {
+        let hint = ContentHint::default();
+        let opts = CompressOptions {
+            max_inline_chars: Some(80),
+            ..Default::default()
+        };
+        let content = (0..40)
+            .map(|i| format!("ordinary output line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let compressor = GenericCompressor;
+
+        let output = compressor
+            .compress(
+                &input(&content, &hint, Some("custom command".into()), None),
+                &opts,
+            )
+            .await
+            .expect("command output should use generic fallback");
+
+        assert_eq!(output.kind, CompressorKind::Generic);
+        assert!(output.lossy);
+        assert!(output.text.len() < content.len());
+    }
+}

--- a/src/compressors/ml_text.rs
+++ b/src/compressors/ml_text.rs
@@ -44,3 +44,54 @@ impl Compressor for MlTextCompressor {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ContentHint, ContentKind};
+
+    fn input<'a>(content: &'a str, hint: &'a ContentHint) -> CompressInput<'a> {
+        CompressInput {
+            content,
+            kind: ContentKind::PlainText,
+            hint,
+            exit_code: None,
+            command: None,
+            argv: None,
+            original_bytes: content.len(),
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_option_declines_without_touching_callback() {
+        let hint = ContentHint::default();
+        let opts = CompressOptions {
+            ml_text_enabled: false,
+            ..Default::default()
+        };
+        let compressor = MlTextCompressor;
+
+        let output = compressor
+            .compress(&input("plain text", &hint), &opts)
+            .await;
+
+        assert!(output.is_none());
+    }
+
+    #[tokio::test]
+    async fn enabled_option_declines_when_no_callback_is_available() {
+        crate::ml::configure_callback(None);
+        let hint = ContentHint::default();
+        let opts = CompressOptions {
+            ml_text_enabled: true,
+            ..Default::default()
+        };
+        let compressor = MlTextCompressor;
+
+        let output = compressor
+            .compress(&input("plain text", &hint), &opts)
+            .await;
+
+        assert!(output.is_none());
+    }
+}

--- a/src/compressors/mod.rs
+++ b/src/compressors/mod.rs
@@ -73,3 +73,26 @@ pub fn compressor_for(kind: ContentKind) -> &'static dyn Compressor {
 pub fn generic_compressor() -> &'static dyn Compressor {
     &GENERIC_COMPRESSOR
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_maps_all_content_kinds_to_expected_compressors() {
+        let cases = [
+            (ContentKind::Json, CompressorKind::SmartCrusher),
+            (ContentKind::Code, CompressorKind::Code),
+            (ContentKind::Log, CompressorKind::Log),
+            (ContentKind::Search, CompressorKind::Search),
+            (ContentKind::Diff, CompressorKind::Diff),
+            (ContentKind::Html, CompressorKind::Html),
+            (ContentKind::PlainText, CompressorKind::MlText),
+        ];
+
+        for (kind, expected) in cases {
+            assert_eq!(compressor_for(kind).kind(), expected);
+        }
+        assert_eq!(generic_compressor().kind(), CompressorKind::Generic);
+    }
+}

--- a/src/ml.rs
+++ b/src/ml.rs
@@ -35,3 +35,61 @@ pub async fn compress(text: &str, opts: &CompressOptions) -> Result<Option<Strin
     };
     callback(text.to_string(), opts.clone()).await
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::Mutex;
+
+    static TEST_LOCK: Mutex<()> = Mutex::const_new(());
+
+    #[tokio::test]
+    async fn declines_when_no_callback_is_configured() {
+        let _guard = TEST_LOCK.lock().await;
+        configure_callback(None);
+
+        let result = compress("plain text", &CompressOptions::default())
+            .await
+            .expect("missing callback is not an error");
+
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn delegates_to_configured_callback_with_owned_options() {
+        let _guard = TEST_LOCK.lock().await;
+        configure_callback(Some(Arc::new(|text, opts| {
+            Box::pin(async move {
+                assert_eq!(text, "alpha beta gamma");
+                assert!(opts.ml_text_enabled);
+                Ok(Some("alpha gamma".to_string()))
+            })
+        })));
+
+        let opts = CompressOptions {
+            ml_text_enabled: true,
+            ..Default::default()
+        };
+        let result = compress("alpha beta gamma", &opts)
+            .await
+            .expect("callback result should propagate");
+
+        assert_eq!(result.as_deref(), Some("alpha gamma"));
+        configure_callback(None);
+    }
+
+    #[tokio::test]
+    async fn propagates_callback_errors() {
+        let _guard = TEST_LOCK.lock().await;
+        configure_callback(Some(Arc::new(|_, _| {
+            Box::pin(async { Err("runtime offline".to_string()) })
+        })));
+
+        let error = compress("alpha beta gamma", &CompressOptions::default())
+            .await
+            .expect_err("callback errors should be returned to caller");
+
+        assert_eq!(error, "runtime offline");
+        configure_callback(None);
+    }
+}

--- a/src/savings.rs
+++ b/src/savings.rs
@@ -35,3 +35,39 @@ pub fn record(
         recorder(content_kind, compressor, original_tokens, compacted_tokens);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn no_recorder_is_a_noop() {
+        configure_recorder(None);
+        record(ContentKind::Json, CompressorKind::SmartCrusher, 100, 25);
+    }
+
+    #[test]
+    fn configured_recorder_receives_compaction_event() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&events);
+        configure_recorder(Some(Arc::new(
+            move |kind, compressor, original, compacted| {
+                captured
+                    .lock()
+                    .unwrap()
+                    .push((kind, compressor, original, compacted));
+            },
+        )));
+
+        record(ContentKind::Log, CompressorKind::Log, 400, 120);
+
+        assert!(events.lock().unwrap().contains(&(
+            ContentKind::Log,
+            CompressorKind::Log,
+            400,
+            120
+        )));
+        configure_recorder(None);
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -606,3 +606,90 @@ pub struct RuleFixture {
     #[serde(default)]
     pub options: Option<ReduceOptions>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_profile_labels_are_stable() {
+        assert_eq!(AgentTokenjuiceCompression::Auto.as_str(), "auto");
+        assert_eq!(AgentTokenjuiceCompression::Full.as_str(), "full");
+        assert_eq!(AgentTokenjuiceCompression::Light.as_str(), "light");
+        assert_eq!(AgentTokenjuiceCompression::Off.as_str(), "off");
+    }
+
+    #[test]
+    fn content_kind_labels_are_stable() {
+        let labels = [
+            (ContentKind::Json, "json"),
+            (ContentKind::Code, "code"),
+            (ContentKind::Log, "log"),
+            (ContentKind::Search, "search"),
+            (ContentKind::Diff, "diff"),
+            (ContentKind::Html, "html"),
+            (ContentKind::PlainText, "plain_text"),
+        ];
+
+        for (kind, label) in labels {
+            assert_eq!(kind.as_str(), label);
+        }
+    }
+
+    #[test]
+    fn compressor_kind_labels_are_stable() {
+        let labels = [
+            (CompressorKind::SmartCrusher, "smartcrusher"),
+            (CompressorKind::Code, "code"),
+            (CompressorKind::Log, "log"),
+            (CompressorKind::Search, "search"),
+            (CompressorKind::Diff, "diff"),
+            (CompressorKind::Html, "html"),
+            (CompressorKind::MlText, "ml_text"),
+            (CompressorKind::Generic, "generic"),
+            (CompressorKind::None, "none"),
+        ];
+
+        for (kind, label) in labels {
+            assert_eq!(kind.as_str(), label);
+        }
+    }
+
+    #[test]
+    fn content_hint_for_tool_sets_only_source_tool() {
+        let hint = ContentHint::for_tool("shell");
+
+        assert_eq!(hint.source_tool.as_deref(), Some("shell"));
+        assert!(hint.mime.is_none());
+        assert!(hint.extension.is_none());
+        assert!(hint.query.is_none());
+        assert!(hint.explicit.is_none());
+    }
+
+    #[test]
+    fn compress_output_constructors_set_lossiness_and_facts() {
+        let reformatted = CompressOutput::reformatted("{}".into(), CompressorKind::SmartCrusher);
+        assert!(!reformatted.lossy);
+        assert_eq!(reformatted.kind, CompressorKind::SmartCrusher);
+        assert!(reformatted.facts.is_none());
+
+        let lossy = CompressOutput::lossy("partial".into(), CompressorKind::Log);
+        assert!(lossy.lossy);
+        assert_eq!(lossy.kind, CompressorKind::Log);
+        assert!(lossy.facts.is_none());
+    }
+
+    #[test]
+    fn compressed_output_passthrough_preserves_lengths_and_flags() {
+        let output = CompressedOutput::passthrough("alpha".into(), ContentKind::PlainText);
+
+        assert_eq!(output.text, "alpha");
+        assert_eq!(output.content_kind, ContentKind::PlainText);
+        assert_eq!(output.compressor, CompressorKind::None);
+        assert!(!output.lossy);
+        assert!(!output.applied);
+        assert!(output.ccr_token.is_none());
+        assert_eq!(output.original_bytes, 5);
+        assert_eq!(output.compacted_bytes, 5);
+    }
+}

--- a/tests/e2e_tool_output.rs
+++ b/tests/e2e_tool_output.rs
@@ -145,3 +145,41 @@ async fn exit_code_and_command_reach_the_rule_engine() {
         "unexpected stats shape: {stats:?}"
     );
 }
+
+#[tokio::test]
+async fn generic_command_fallback_is_recoverable_end_to_end() {
+    common::install_test_config();
+    let payload = (0..900)
+        .map(|i| format!("ordinary long-running command output line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let (text, stats) = compact_tool_output_with_policy(
+        "shell",
+        Some(&json!({ "command": "custom-report --verbose" })),
+        &payload,
+        Some(0),
+        AgentTokenjuiceCompression::Full,
+    )
+    .await;
+
+    assert!(
+        stats.applied,
+        "generic fallback should compact command output"
+    );
+    assert!(
+        stats.compacted_bytes < stats.original_bytes,
+        "compaction must shrink: {} -> {}",
+        stats.original_bytes,
+        stats.compacted_bytes
+    );
+
+    let tokens = cache::parse_markers(&text);
+    assert_eq!(
+        tokens.len(),
+        1,
+        "lossy fallback must emit one recovery marker"
+    );
+    let original = cache::retrieve(&tokens[0]).expect("footer token must be retrievable");
+    assert_eq!(original, payload);
+}


### PR DESCRIPTION
## Summary
- Add focused unit tests for the ML callback slot, ML text compressor gating, generic fallback compressor, compressor registry, savings recorder, and stable public type helpers.
- Add an end-to-end regression through `compact_tool_output_with_policy` proving generic command fallback compacts and recovers the original through CCR.
- Raise coverage above the requested target: line coverage is 93.06% and function coverage is 91.92%.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `rustup run stable cargo llvm-cov --all-targets --json --summary-only --output-path target/llvm-cov-summary.json`
