### PR TITLE
[codex] add Codex and Claude SDK integrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "tinyjuice"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinyjuice"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "GPL-3.0-only"
 description = "Pluggable token compression for OpenHuman."

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Add TinyJuice to a Rust project once published:
 
 ```toml
 [dependencies]
-tinyjuice = "0.1"
+tinyjuice = "0.2"
 ```
 
 Use the small public trait scaffold when you want a simple strategy boundary:
@@ -155,6 +155,164 @@ async fn compact_command_output(command_output: &str) {
 }
 ```
 
+## SDK and Plugin Integration
+
+TinyJuice now exposes two integration paths:
+
+- Rust hosts use the crate SDK directly.
+- Non-Rust plugins and harnesses call the `tinyjuice reduce-json` protocol.
+
+The SDK accepts a host-neutral `ToolExecutionInput` with tool name, command,
+argv, stdout/stderr or combined text, exit code, cwd, and metadata. The response
+contains the inline text plus metadata about the applied content kind,
+compressor, token estimate, byte counts, and CCR recovery token when one was
+created. Do not log the request body from adapters; tool output may contain
+prompts, credentials, or private context.
+
+### Rust SDK
+
+```rust
+use tinyjuice::{
+    AgentTokenjuiceCompression, TinyJuiceHost, TinyJuiceSdk, ToolExecutionInput,
+};
+
+async fn compact_for_harness(tool_output: String, exit_code: i32) {
+    let sdk = TinyJuiceSdk::new(TinyJuiceHost::RustHarness)
+        .with_profile(AgentTokenjuiceCompression::Full);
+
+    let response = sdk
+        .compress_tool_output(ToolExecutionInput {
+            tool_name: "shell".to_string(),
+            command: Some("cargo test".to_string()),
+            argv: Some(vec!["cargo".to_string(), "test".to_string()]),
+            combined_text: Some(tool_output),
+            exit_code: Some(exit_code),
+            ..Default::default()
+        })
+        .await;
+
+    println!("{}", response.inline_text);
+}
+```
+
+Use `TinyJuiceHost::OpenHuman` for OpenHuman adapters and
+`TinyJuiceHost::RustHarness` for standalone Rust harnesses. Hosts should map
+their own config into `CompressOptions`, choose the per-agent profile, and expose
+CCR retrieval before enabling lossy compaction in production.
+
+### JSON Protocol
+
+Build the binary locally:
+
+```sh
+cargo build --release --bin tinyjuice
+```
+
+Send a full SDK request:
+
+```json
+{
+  "host": "generic-json",
+  "profile": "full",
+  "input": {
+    "toolName": "shell",
+    "command": "cargo test",
+    "argv": ["cargo", "test"],
+    "combinedText": "large tool output...",
+    "exitCode": 0,
+    "metadata": {
+      "source": "custom-harness"
+    }
+  },
+  "options": {
+    "minBytesToCompress": 512,
+    "maxInlineChars": 1200,
+    "ccrEnabled": true
+  }
+}
+```
+
+Run it through the protocol:
+
+```sh
+tinyjuice reduce-json payload.json
+cat payload.json | tinyjuice reduce-json --host generic-json -
+```
+
+A bare `ToolExecutionInput` object is also accepted when the host, profile, and
+options can stay at defaults.
+
+### Codex and Claude Code Hooks
+
+Build or install a `tinyjuice` binary, then merge a hook into the host config:
+
+```sh
+tinyjuice install codex
+tinyjuice install claude-code
+```
+
+The Codex installer updates `~/.codex/hooks.json` with a `PostToolUse` hook for
+`Bash` tool output. When TinyJuice compacts a large result, it emits
+`hookSpecificOutput.additionalContext`, matching Codex's hook output model.
+
+The Claude Code installer updates `~/.claude/settings.json` with a `PostToolUse`
+hook for `Bash` tool output. When TinyJuice compacts a large result, it emits
+`hookSpecificOutput.updatedToolOutput`, so Claude Code sees the compacted tool
+result rather than the noisy original.
+
+Both installers:
+
+- preserve existing hooks and settings
+- replace an older TinyJuice hook for the same host
+- write a `.bak` file next to the edited JSON file
+- expect `tinyjuice` to be on `PATH` unless `--binary` is supplied
+
+Examples:
+
+```sh
+tinyjuice install codex --binary /usr/local/bin/tinyjuice
+tinyjuice install claude-code --path ~/.claude/settings.json
+```
+
+The raw hook entrypoints are also available for custom installers:
+
+```sh
+tinyjuice codex-post-tool-use
+tinyjuice claude-code-post-tool-use
+```
+
+Hook invocations use a disk-backed CCR store so recovery tokens survive the
+short-lived hook process. By default the store lives under the user's cache
+directory at `tinyjuice/ccr`; override it with:
+
+```sh
+export TINYJUICE_CCR_DIR=/path/to/tinyjuice-ccr
+```
+
+Recover a full original from a hook footer:
+
+```sh
+tinyjuice retrieve <token>
+```
+
+Useful hook tuning variables:
+
+```sh
+export TINYJUICE_MIN_BYTES_TO_COMPRESS=2048
+export TINYJUICE_MAX_INLINE_CHARS=1200
+export TINYJUICE_CCR_MIN_TOKENS=500
+export TINYJUICE_CCR_ENABLED=true
+```
+
+Templates remain available for inspection or custom packaging:
+
+```sh
+tinyjuice hosts
+tinyjuice host-template codex
+tinyjuice host-template claude-code
+tinyjuice host-template generic-json
+```
+
 ## Local Development
 
 ```sh
@@ -162,6 +320,8 @@ cargo fmt --check
 cargo clippy --all-targets -- -D warnings
 cargo test
 cargo run --example passthrough
+cargo run --bin tinyjuice -- hosts
+cargo run --bin tinyjuice -- host-template codex
 ```
 
 Run hot-path benchmarks:
@@ -191,6 +351,7 @@ src/
   cache/             CCR offload, retrieval markers, memory/disk store
   rules/             Built-in + user + project command reduction rules
   reduce.rs          Rule-engine reduction pipeline
+  sdk.rs             Host-neutral SDK and reduce-json request/response types
   tool_integration.rs OpenHuman-style tool-output adapter
   compressor/        Small public Compressor trait scaffold
   config/            Small public CompressionConfig scaffold

--- a/src/bin/tinyjuice.rs
+++ b/src/bin/tinyjuice.rs
@@ -1,0 +1,509 @@
+use std::env;
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::str::FromStr;
+
+use serde_json::{Map, Value};
+use tinyjuice::{
+    SdkCompressOptions, TinyJuiceHost, compress_host_hook_payload, compress_request,
+    host_install_specs, host_template, request_from_json_value,
+};
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("tinyjuice: {error}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn run() -> Result<(), String> {
+    let mut args = env::args().skip(1).collect::<Vec<_>>();
+    let Some(command) = args.first().cloned() else {
+        print_usage();
+        return Ok(());
+    };
+    args.remove(0);
+
+    match command.as_str() {
+        "reduce-json" => reduce_json(args),
+        "codex-post-tool-use" => post_tool_use_hook(TinyJuiceHost::Codex),
+        "claude-code-post-tool-use" => post_tool_use_hook(TinyJuiceHost::ClaudeCode),
+        "install" => install_command(args),
+        "retrieve" => retrieve_command(args),
+        "hosts" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&host_install_specs())
+                    .map_err(|error| error.to_string())?
+            );
+            Ok(())
+        }
+        "host-template" => host_template_command(args),
+        "help" | "--help" | "-h" => {
+            print_usage();
+            Ok(())
+        }
+        other => Err(format!("unknown command '{other}'")),
+    }
+}
+
+fn reduce_json(args: Vec<String>) -> Result<(), String> {
+    configure_cli_cache();
+    let mut host_override = None;
+    let mut path = None;
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--host" => {
+                let value = args
+                    .get(index + 1)
+                    .ok_or_else(|| "--host requires a value".to_string())?;
+                host_override = Some(TinyJuiceHost::from_str(value)?);
+                index += 2;
+            }
+            "--help" | "-h" => {
+                print_usage();
+                return Ok(());
+            }
+            value if value.starts_with("--host=") => {
+                host_override = Some(TinyJuiceHost::from_str(&value["--host=".len()..])?);
+                index += 1;
+            }
+            value if value.starts_with('-') && value != "-" => {
+                return Err(format!("unknown reduce-json flag '{value}'"));
+            }
+            value => {
+                if path.replace(value.to_string()).is_some() {
+                    return Err("reduce-json accepts at most one path".to_string());
+                }
+                index += 1;
+            }
+        }
+    }
+
+    let input = read_input(path.as_deref())?;
+    let value = serde_json::from_str(&input).map_err(|error| format!("invalid JSON: {error}"))?;
+    let mut request = request_from_json_value(value).map_err(|error| error.to_string())?;
+    if let Some(host) = host_override {
+        request.host = host;
+    }
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| error.to_string())?;
+    let response = runtime.block_on(compress_request(request));
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&response).map_err(|error| error.to_string())?
+    );
+    Ok(())
+}
+
+fn post_tool_use_hook(host: TinyJuiceHost) -> Result<(), String> {
+    configure_cli_cache();
+    let input = read_input(None)?;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| error.to_string())?;
+    let result = runtime.block_on(compress_host_hook_payload(
+        host,
+        &input,
+        hook_options_from_env(),
+    ));
+    if let Ok(Some(value)) = result {
+        println!(
+            "{}",
+            serde_json::to_string(&value).map_err(|error| error.to_string())?
+        );
+    }
+    Ok(())
+}
+
+fn install_command(args: Vec<String>) -> Result<(), String> {
+    let mut binary = "tinyjuice".to_string();
+    let mut path = None;
+    let mut host = None;
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--binary" => {
+                binary = args
+                    .get(index + 1)
+                    .ok_or_else(|| "--binary requires a value".to_string())?
+                    .to_string();
+                index += 2;
+            }
+            value if value.starts_with("--binary=") => {
+                binary = value["--binary=".len()..].to_string();
+                index += 1;
+            }
+            "--path" => {
+                path = Some(PathBuf::from(
+                    args.get(index + 1)
+                        .ok_or_else(|| "--path requires a value".to_string())?,
+                ));
+                index += 2;
+            }
+            value if value.starts_with("--path=") => {
+                path = Some(PathBuf::from(&value["--path=".len()..]));
+                index += 1;
+            }
+            "--help" | "-h" => {
+                print_usage();
+                return Ok(());
+            }
+            value if value.starts_with('-') => {
+                return Err(format!("unknown install flag '{value}'"));
+            }
+            value => {
+                if host.replace(TinyJuiceHost::from_str(value)?).is_some() {
+                    return Err("install accepts exactly one host".to_string());
+                }
+                index += 1;
+            }
+        }
+    }
+    let host = host.ok_or_else(|| "install requires a host".to_string())?;
+    if !matches!(host, TinyJuiceHost::Codex | TinyJuiceHost::ClaudeCode) {
+        return Err(format!("install is not implemented for {}", host.id()));
+    }
+    let install_path = path.unwrap_or_else(|| default_hook_path(host));
+    let backup_path = install_hook_config(host, &install_path, &binary)?;
+    println!(
+        "installed {} hook at {}{}",
+        host.id(),
+        install_path.display(),
+        backup_path
+            .as_ref()
+            .map(|path| format!(" (backup: {})", path.display()))
+            .unwrap_or_default()
+    );
+    Ok(())
+}
+
+fn retrieve_command(args: Vec<String>) -> Result<(), String> {
+    configure_cli_cache();
+    let token = args
+        .first()
+        .ok_or_else(|| "retrieve requires a CCR token".to_string())?;
+    if args.len() > 1 {
+        return Err("retrieve accepts exactly one CCR token".to_string());
+    }
+    let Some(original) = tinyjuice::cache::retrieve(token) else {
+        return Err(format!("no original found for token {token}"));
+    };
+    print!("{original}");
+    Ok(())
+}
+
+fn host_template_command(args: Vec<String>) -> Result<(), String> {
+    let mut binary = "tinyjuice".to_string();
+    let mut host = None;
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--binary" => {
+                binary = args
+                    .get(index + 1)
+                    .ok_or_else(|| "--binary requires a value".to_string())?
+                    .to_string();
+                index += 2;
+            }
+            value if value.starts_with("--binary=") => {
+                binary = value["--binary=".len()..].to_string();
+                index += 1;
+            }
+            "--help" | "-h" => {
+                print_usage();
+                return Ok(());
+            }
+            value if value.starts_with('-') => {
+                return Err(format!("unknown host-template flag '{value}'"));
+            }
+            value => {
+                if host.replace(TinyJuiceHost::from_str(value)?).is_some() {
+                    return Err("host-template accepts exactly one host".to_string());
+                }
+                index += 1;
+            }
+        }
+    }
+    let host = host.ok_or_else(|| "host-template requires a host".to_string())?;
+    println!("{}", host_template(host, &binary));
+    Ok(())
+}
+
+fn read_input(path: Option<&str>) -> Result<String, String> {
+    match path {
+        Some("-") | None => {
+            let mut input = String::new();
+            io::stdin()
+                .read_to_string(&mut input)
+                .map_err(|error| error.to_string())?;
+            Ok(input)
+        }
+        Some(path) => fs::read_to_string(path).map_err(|error| error.to_string()),
+    }
+}
+
+fn configure_cli_cache() {
+    tinyjuice::cache::enable_disk_tier(cli_cache_root());
+}
+
+fn cli_cache_root() -> PathBuf {
+    if let Ok(path) = env::var("TINYJUICE_CCR_DIR")
+        && !path.trim().is_empty()
+    {
+        return PathBuf::from(path);
+    }
+    dirs::cache_dir()
+        .unwrap_or_else(env::temp_dir)
+        .join("tinyjuice")
+        .join("ccr")
+}
+
+fn hook_options_from_env() -> SdkCompressOptions {
+    SdkCompressOptions {
+        min_bytes_to_compress: read_usize_env("TINYJUICE_MIN_BYTES_TO_COMPRESS"),
+        max_inline_chars: read_usize_env("TINYJUICE_MAX_INLINE_CHARS"),
+        ccr_min_tokens: read_usize_env("TINYJUICE_CCR_MIN_TOKENS"),
+        ccr_enabled: read_bool_env("TINYJUICE_CCR_ENABLED"),
+        ..Default::default()
+    }
+}
+
+fn read_usize_env(name: &str) -> Option<usize> {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+}
+
+fn read_bool_env(name: &str) -> Option<bool> {
+    env::var(name)
+        .ok()
+        .and_then(|value| match value.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => Some(true),
+            "0" | "false" | "no" | "off" => Some(false),
+            _ => None,
+        })
+}
+
+fn default_hook_path(host: TinyJuiceHost) -> PathBuf {
+    match host {
+        TinyJuiceHost::Codex => env::var("CODEX_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| home_dir().join(".codex"))
+            .join("hooks.json"),
+        TinyJuiceHost::ClaudeCode => env::var("CLAUDE_CONFIG_DIR")
+            .or_else(|_| env::var("CLAUDE_HOME"))
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| home_dir().join(".claude"))
+            .join("settings.json"),
+        TinyJuiceHost::GenericJson | TinyJuiceHost::OpenHuman | TinyJuiceHost::RustHarness => {
+            home_dir()
+        }
+    }
+}
+
+fn home_dir() -> PathBuf {
+    dirs::home_dir().unwrap_or_else(env::temp_dir)
+}
+
+fn install_hook_config(
+    host: TinyJuiceHost,
+    path: &Path,
+    binary: &str,
+) -> Result<Option<PathBuf>, String> {
+    let template: Value =
+        serde_json::from_str(&host_template(host, binary)).map_err(|error| error.to_string())?;
+    let (mut config, backup_path) = load_or_empty_json(path)?;
+    merge_template_hooks(&mut config, &template, host)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+    let temp_path = path.with_extension("tmp");
+    fs::write(
+        &temp_path,
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&config).map_err(|error| error.to_string())?
+        ),
+    )
+    .map_err(|error| error.to_string())?;
+    fs::rename(&temp_path, path).map_err(|error| error.to_string())?;
+    Ok(backup_path)
+}
+
+fn load_or_empty_json(path: &Path) -> Result<(Value, Option<PathBuf>), String> {
+    match fs::read_to_string(path) {
+        Ok(existing) => {
+            let parsed =
+                serde_json::from_str(&existing).unwrap_or_else(|_| Value::Object(Map::new()));
+            let backup_path = path.with_extension("bak");
+            fs::write(&backup_path, existing).map_err(|error| error.to_string())?;
+            Ok((parsed, Some(backup_path)))
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            Ok((Value::Object(Map::new()), None))
+        }
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+fn merge_template_hooks(
+    config: &mut Value,
+    template: &Value,
+    host: TinyJuiceHost,
+) -> Result<(), String> {
+    let hooks = ensure_object_field(config, "hooks")?;
+    let template_hooks = template
+        .get("hooks")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "host template did not contain hooks object".to_string())?;
+    for (event, groups) in template_hooks {
+        let event_groups = ensure_array_field(hooks, event);
+        prune_tinyjuice_hook_groups(event_groups, host);
+        let template_groups = groups
+            .as_array()
+            .ok_or_else(|| format!("template hooks.{event} is not an array"))?;
+        event_groups.extend(template_groups.iter().cloned());
+    }
+    Ok(())
+}
+
+fn ensure_object_field<'a>(
+    value: &'a mut Value,
+    key: &str,
+) -> Result<&'a mut Map<String, Value>, String> {
+    if !value.is_object() {
+        *value = Value::Object(Map::new());
+    }
+    let object = value
+        .as_object_mut()
+        .ok_or_else(|| "expected JSON object".to_string())?;
+    if !object.get(key).is_some_and(Value::is_object) {
+        object.insert(key.to_string(), Value::Object(Map::new()));
+    }
+    object
+        .get_mut(key)
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| format!("expected {key} object"))
+}
+
+fn ensure_array_field<'a>(object: &'a mut Map<String, Value>, key: &str) -> &'a mut Vec<Value> {
+    if !object.get(key).is_some_and(Value::is_array) {
+        object.insert(key.to_string(), Value::Array(Vec::new()));
+    }
+    object
+        .get_mut(key)
+        .and_then(Value::as_array_mut)
+        .expect("array field inserted")
+}
+
+fn prune_tinyjuice_hook_groups(groups: &mut Vec<Value>, host: TinyJuiceHost) {
+    groups.retain_mut(|group| {
+        let Some(hooks) = group.get_mut("hooks").and_then(Value::as_array_mut) else {
+            return true;
+        };
+        hooks.retain(|hook| !is_tinyjuice_hook(hook, host));
+        !hooks.is_empty()
+    });
+}
+
+fn is_tinyjuice_hook(hook: &Value, host: TinyJuiceHost) -> bool {
+    let status = hook
+        .get("statusMessage")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let command = hook
+        .get("command")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let subcommand = match host {
+        TinyJuiceHost::Codex => "codex-post-tool-use",
+        TinyJuiceHost::ClaudeCode => "claude-code-post-tool-use",
+        TinyJuiceHost::GenericJson | TinyJuiceHost::OpenHuman | TinyJuiceHost::RustHarness => "",
+    };
+    status.contains("tinyjuice") || (!subcommand.is_empty() && command.contains(subcommand))
+}
+
+fn print_usage() {
+    eprintln!(
+        r#"Usage:
+  tinyjuice reduce-json [--host HOST] [payload.json|-]
+  tinyjuice codex-post-tool-use
+  tinyjuice claude-code-post-tool-use
+  tinyjuice install HOST [--path PATH] [--binary PATH]
+  tinyjuice retrieve TOKEN
+  tinyjuice hosts
+  tinyjuice host-template HOST [--binary PATH]
+
+Hosts: generic-json, openhuman, codex, claude-code, rust-harness"#
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_merges_without_removing_existing_hooks() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("hooks.json");
+        fs::write(
+            &path,
+            r#"{"hooks":{"PostToolUse":[{"matcher":"Edit","hooks":[{"type":"command","command":"echo keep"}]}]}}"#,
+        )
+        .expect("write");
+
+        let backup =
+            install_hook_config(TinyJuiceHost::Codex, &path, "tinyjuice").expect("install");
+        assert!(backup.expect("backup").exists());
+
+        let installed: Value =
+            serde_json::from_str(&fs::read_to_string(path).expect("read")).expect("json");
+        let groups = installed["hooks"]["PostToolUse"]
+            .as_array()
+            .expect("groups");
+        assert_eq!(groups.len(), 2);
+        assert!(
+            groups
+                .iter()
+                .any(|group| group["hooks"][0]["command"].as_str() == Some("echo keep"))
+        );
+        assert!(groups.iter().any(|group| {
+            group["hooks"][0]["command"]
+                .as_str()
+                .is_some_and(|command| command.contains("codex-post-tool-use"))
+        }));
+    }
+
+    #[test]
+    fn reinstall_replaces_tinyjuice_hook() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.json");
+
+        install_hook_config(TinyJuiceHost::ClaudeCode, &path, "tinyjuice").expect("install");
+        install_hook_config(TinyJuiceHost::ClaudeCode, &path, "/opt/tinyjuice").expect("reinstall");
+
+        let installed: Value =
+            serde_json::from_str(&fs::read_to_string(path).expect("read")).expect("json");
+        let groups = installed["hooks"]["PostToolUse"]
+            .as_array()
+            .expect("groups");
+        assert_eq!(groups.len(), 1);
+        assert_eq!(
+            groups[0]["hooks"][0]["command"].as_str(),
+            Some("/opt/tinyjuice claude-code-post-tool-use")
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod openhuman;
 pub mod reduce;
 pub mod rules;
 pub mod savings;
+pub mod sdk;
 pub mod text;
 pub mod tokens;
 pub mod tool_integration;
@@ -33,6 +34,12 @@ pub use detect::detect_content_kind;
 pub use error::{TinyJuiceError, TinyJuiceResult};
 pub use reduce::reduce_execution_with_rules;
 pub use rules::{LoadRuleOptions, load_builtin_rules, load_rules};
+pub use sdk::{
+    HostInstallSpec, SdkCompressOptions, SdkCompressionClassification, SdkCompressionRequest,
+    SdkCompressionResponse, SdkCompressionStats, TinyJuiceHost, TinyJuiceSdk, arguments_value,
+    compress_host_hook_payload, compress_request, host_hook_response, host_install_spec,
+    host_install_specs, host_template, request_from_json_value,
+};
 pub use tool_integration::{
     CompactionStats, compact_output, compact_output_with_policy, compact_tool_output_with_policy,
     configure, current_options, install_config,

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -1,0 +1,956 @@
+//! Host-neutral SDK and plugin adapter surface.
+//!
+//! This module is the stable boundary for Rust harnesses and for non-Rust hosts
+//! that call the `tinyjuice reduce-json` protocol. It keeps host integration
+//! metadata, request/response JSON, and conservative profile policy close to
+//! the core router without importing any host runtime dependencies.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use crate::compress::route;
+use crate::tokens::estimate_tokens;
+use crate::types::{
+    AgentTokenjuiceCompression, CompressInput, CompressOptions, CompressedOutput, ContentHint,
+    ContentKind, ToolExecutionInput,
+};
+
+const CODEX_HOOK_STATUS: &str = "compressing Bash output with TinyJuice";
+const CLAUDE_CODE_HOOK_STATUS: &str = "compressing Bash output with TinyJuice";
+
+/// Supported host/plugin integration targets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum TinyJuiceHost {
+    /// Generic stdin/stdout JSON protocol for custom harnesses.
+    #[default]
+    GenericJson,
+    /// OpenHuman or another Rust host calling the crate directly.
+    #[serde(rename = "openhuman")]
+    OpenHuman,
+    /// OpenAI Codex-style hook/plugin integration.
+    Codex,
+    /// Claude Code-style hook/plugin integration.
+    ClaudeCode,
+    /// Rust agent harnesses such as TinyAgents/RustAgents.
+    RustHarness,
+}
+
+impl TinyJuiceHost {
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::GenericJson => "generic-json",
+            Self::OpenHuman => "openhuman",
+            Self::Codex => "codex",
+            Self::ClaudeCode => "claude-code",
+            Self::RustHarness => "rust-harness",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::GenericJson => "Generic JSON harness",
+            Self::OpenHuman => "OpenHuman",
+            Self::Codex => "Codex",
+            Self::ClaudeCode => "Claude Code",
+            Self::RustHarness => "Rust harness",
+        }
+    }
+}
+
+impl FromStr for TinyJuiceHost {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "generic-json" | "generic" | "json" => Ok(Self::GenericJson),
+            "openhuman" | "open-human" => Ok(Self::OpenHuman),
+            "codex" => Ok(Self::Codex),
+            "claude-code" | "claude" => Ok(Self::ClaudeCode),
+            "rust-harness" | "rust" | "harness" => Ok(Self::RustHarness),
+            other => Err(format!("unknown TinyJuice host '{other}'")),
+        }
+    }
+}
+
+/// Serializable compression options accepted by SDK requests.
+///
+/// Every field is optional so plugin/harness callers can send only the knobs
+/// they own. Missing values inherit [`CompressOptions::default`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SdkCompressOptions {
+    #[serde(default)]
+    pub router_enabled: Option<bool>,
+    #[serde(default)]
+    pub ccr_enabled: Option<bool>,
+    #[serde(default)]
+    pub search_enabled: Option<bool>,
+    #[serde(default)]
+    pub code_enabled: Option<bool>,
+    #[serde(default)]
+    pub html_enabled: Option<bool>,
+    #[serde(default)]
+    pub ml_text_enabled: Option<bool>,
+    #[serde(default)]
+    pub min_bytes_to_compress: Option<usize>,
+    #[serde(default)]
+    pub ccr_min_tokens: Option<usize>,
+    #[serde(default)]
+    pub max_inline_chars: Option<usize>,
+}
+
+impl SdkCompressOptions {
+    pub fn into_compress_options(self) -> CompressOptions {
+        let mut opts = CompressOptions::default();
+        if let Some(value) = self.router_enabled {
+            opts.router_enabled = value;
+        }
+        if let Some(value) = self.ccr_enabled {
+            opts.ccr_enabled = value;
+        }
+        if let Some(value) = self.search_enabled {
+            opts.search_enabled = value;
+        }
+        if let Some(value) = self.code_enabled {
+            opts.code_enabled = value;
+        }
+        if let Some(value) = self.html_enabled {
+            opts.html_enabled = value;
+        }
+        if let Some(value) = self.ml_text_enabled {
+            opts.ml_text_enabled = value;
+        }
+        if let Some(value) = self.min_bytes_to_compress {
+            opts.min_bytes_to_compress = value;
+        }
+        if let Some(value) = self.ccr_min_tokens {
+            opts.ccr_min_tokens = value;
+        }
+        if let Some(value) = self.max_inline_chars {
+            opts.max_inline_chars = Some(value);
+        }
+        opts
+    }
+}
+
+/// Stable SDK request shape for tool-output compression.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SdkCompressionRequest {
+    #[serde(default)]
+    pub host: TinyJuiceHost,
+    #[serde(default)]
+    pub profile: AgentTokenjuiceCompression,
+    #[serde(default)]
+    pub input: ToolExecutionInput,
+    #[serde(default)]
+    pub options: SdkCompressOptions,
+}
+
+impl SdkCompressionRequest {
+    pub fn new(input: ToolExecutionInput) -> Self {
+        Self {
+            input,
+            ..Default::default()
+        }
+    }
+}
+
+/// SDK response stats. Character counts mirror the cross-language JSON
+/// protocol, while byte/token counts are included for Rust hosts and dashboards.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SdkCompressionStats {
+    pub raw_chars: usize,
+    pub reduced_chars: usize,
+    pub ratio: f64,
+    pub original_bytes: usize,
+    pub compacted_bytes: usize,
+    pub original_tokens: usize,
+    pub compacted_tokens: usize,
+}
+
+/// Classification/strategy metadata without raw content.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SdkCompressionClassification {
+    pub family: String,
+    pub content_kind: String,
+    pub compressor: String,
+    pub confidence: f64,
+    #[serde(default)]
+    pub matched_reducer: Option<String>,
+}
+
+/// Stable SDK response shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SdkCompressionResponse {
+    pub inline_text: String,
+    #[serde(default)]
+    pub preview_text: Option<String>,
+    pub stats: SdkCompressionStats,
+    pub classification: SdkCompressionClassification,
+    pub host: TinyJuiceHost,
+    pub profile: AgentTokenjuiceCompression,
+    pub applied: bool,
+    pub lossy: bool,
+    #[serde(default)]
+    pub ccr_token: Option<String>,
+}
+
+/// Host integration metadata suitable for docs, installers, or plugin UIs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostInstallSpec {
+    pub host: TinyJuiceHost,
+    pub label: String,
+    pub install_command: String,
+    pub hook_file: String,
+    pub hook_event: String,
+    pub description: String,
+    pub notes: Vec<String>,
+}
+
+/// A configured TinyJuice SDK client for direct Rust use.
+#[derive(Debug, Clone)]
+pub struct TinyJuiceSdk {
+    host: TinyJuiceHost,
+    profile: AgentTokenjuiceCompression,
+    options: CompressOptions,
+}
+
+impl TinyJuiceSdk {
+    pub fn new(host: TinyJuiceHost) -> Self {
+        Self {
+            host,
+            profile: AgentTokenjuiceCompression::Full,
+            options: CompressOptions::default(),
+        }
+    }
+
+    pub fn with_profile(mut self, profile: AgentTokenjuiceCompression) -> Self {
+        self.profile = profile;
+        self
+    }
+
+    pub fn with_options(mut self, options: CompressOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    pub async fn compress_tool_output(&self, input: ToolExecutionInput) -> SdkCompressionResponse {
+        compress_request(SdkCompressionRequest {
+            host: self.host,
+            profile: self.profile,
+            input,
+            options: SdkCompressOptions::from(self.options.clone()),
+        })
+        .await
+    }
+}
+
+/// Compress one raw hook payload and return a host-native hook response.
+///
+/// Returns `None` when the payload is not a matching post-tool hook, has no
+/// compressible output, or TinyJuice declines to rewrite the content.
+pub async fn compress_host_hook_payload(
+    host: TinyJuiceHost,
+    raw_json: &str,
+    options: SdkCompressOptions,
+) -> Result<Option<Value>, serde_json::Error> {
+    let value = serde_json::from_str(raw_json)?;
+    if !is_supported_post_tool_payload(host, &value) {
+        return Ok(None);
+    }
+    let mut request = request_from_json_value(value)?;
+    request.host = host;
+    request.options = options;
+    let response = compress_request(request).await;
+    Ok(host_hook_response(&response))
+}
+
+/// Build the JSON object a hook command should print for the host.
+pub fn host_hook_response(response: &SdkCompressionResponse) -> Option<Value> {
+    if !response.applied {
+        return None;
+    }
+    let inline_text = decorate_hook_inline_text(response);
+    match response.host {
+        TinyJuiceHost::Codex => Some(serde_json::json!({
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": inline_text
+            }
+        })),
+        TinyJuiceHost::ClaudeCode => Some(serde_json::json!({
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "updatedToolOutput": inline_text
+            }
+        })),
+        TinyJuiceHost::GenericJson | TinyJuiceHost::OpenHuman | TinyJuiceHost::RustHarness => None,
+    }
+}
+
+impl From<CompressOptions> for SdkCompressOptions {
+    fn from(value: CompressOptions) -> Self {
+        Self {
+            router_enabled: Some(value.router_enabled),
+            ccr_enabled: Some(value.ccr_enabled),
+            search_enabled: Some(value.search_enabled),
+            code_enabled: Some(value.code_enabled),
+            html_enabled: Some(value.html_enabled),
+            ml_text_enabled: Some(value.ml_text_enabled),
+            min_bytes_to_compress: Some(value.min_bytes_to_compress),
+            ccr_min_tokens: Some(value.ccr_min_tokens),
+            max_inline_chars: value.max_inline_chars,
+        }
+    }
+}
+
+/// Compress one SDK request.
+pub async fn compress_request(request: SdkCompressionRequest) -> SdkCompressionResponse {
+    let original_text = tool_output_text(&request.input);
+    let mut opts = request.options.into_compress_options();
+
+    match request.profile {
+        AgentTokenjuiceCompression::Off => {
+            return response_from_output(
+                request.host,
+                request.profile,
+                &original_text,
+                CompressedOutput::passthrough(original_text.clone(), ContentKind::PlainText),
+            );
+        }
+        AgentTokenjuiceCompression::Light => {
+            opts.ccr_enabled = false;
+            opts.ml_text_enabled = false;
+        }
+        AgentTokenjuiceCompression::Auto | AgentTokenjuiceCompression::Full => {}
+    }
+
+    let hint = hint_from_tool_input(&request.input);
+    let route_input = CompressInput {
+        content: &original_text,
+        kind: ContentKind::PlainText,
+        hint: &hint,
+        exit_code: request.input.exit_code,
+        command: request.input.command.clone(),
+        argv: request.input.argv.clone(),
+        original_bytes: original_text.len(),
+    };
+    let output = route(route_input, &opts).await;
+    response_from_output(request.host, request.profile, &original_text, output)
+}
+
+/// Return install metadata for all first-class host surfaces.
+pub fn host_install_specs() -> Vec<HostInstallSpec> {
+    [
+        TinyJuiceHost::OpenHuman,
+        TinyJuiceHost::RustHarness,
+        TinyJuiceHost::Codex,
+        TinyJuiceHost::ClaudeCode,
+        TinyJuiceHost::GenericJson,
+    ]
+    .into_iter()
+    .map(host_install_spec)
+    .collect()
+}
+
+/// Return install metadata for one host surface.
+pub fn host_install_spec(host: TinyJuiceHost) -> HostInstallSpec {
+    match host {
+        TinyJuiceHost::OpenHuman => HostInstallSpec {
+            host,
+            label: host.label().to_string(),
+            install_command: r#"cargo add tinyjuice"#.to_string(),
+            hook_file: "host Rust tool-output adapter".to_string(),
+            hook_event: "post-tool-output".to_string(),
+            description: "Call the crate directly after tool output is captured and scrubbed."
+                .to_string(),
+            notes: vec![
+                "Map host config into CompressOptions.".to_string(),
+                "Expose a tokenjuice_retrieve tool before enabling lossy CCR views.".to_string(),
+            ],
+        },
+        TinyJuiceHost::RustHarness => HostInstallSpec {
+            host,
+            label: host.label().to_string(),
+            install_command: r#"cargo add tinyjuice"#.to_string(),
+            hook_file: "harness post-tool hook".to_string(),
+            hook_event: "post-tool-output".to_string(),
+            description: "Use TinyJuiceSdk or compress_request inside the Rust harness loop."
+                .to_string(),
+            notes: vec![
+                "Pass command, argv, exit code, and cwd when available.".to_string(),
+                "Do not log raw tool output from adapter diagnostics.".to_string(),
+            ],
+        },
+        TinyJuiceHost::Codex => HostInstallSpec {
+            host,
+            label: host.label().to_string(),
+            install_command: r#"tinyjuice install codex"#.to_string(),
+            hook_file: "~/.codex/hooks.json".to_string(),
+            hook_event: "PostToolUse".to_string(),
+            description: "Install a Codex PostToolUse hook for Bash output.".to_string(),
+            notes: vec![
+                "The installer merges with existing hooks and writes a backup.".to_string(),
+                "The hook expects a tinyjuice binary on PATH.".to_string(),
+            ],
+        },
+        TinyJuiceHost::ClaudeCode => HostInstallSpec {
+            host,
+            label: host.label().to_string(),
+            install_command: r#"tinyjuice install claude-code"#.to_string(),
+            hook_file: "~/.claude/settings.json".to_string(),
+            hook_event: "PostToolUse".to_string(),
+            description: "Install a Claude Code PostToolUse hook for Bash output.".to_string(),
+            notes: vec![
+                "The installer merges with existing settings and writes a backup.".to_string(),
+                "Claude Code supports updatedToolOutput, so TinyJuice can replace noisy output."
+                    .to_string(),
+            ],
+        },
+        TinyJuiceHost::GenericJson => HostInstallSpec {
+            host,
+            label: host.label().to_string(),
+            install_command: r#"tinyjuice reduce-json payload.json"#.to_string(),
+            hook_file: "stdin/stdout JSON".to_string(),
+            hook_event: "post-tool-output".to_string(),
+            description: "Pipe a stable JSON request into TinyJuice from any harness.".to_string(),
+            notes: vec![
+                "Use combinedText for already-merged output, or stdout/stderr fields otherwise."
+                    .to_string(),
+                "The response never includes raw content except inlineText.".to_string(),
+            ],
+        },
+    }
+}
+
+/// Render a starter hook/template for a host.
+pub fn host_template(host: TinyJuiceHost, binary: &str) -> String {
+    match host {
+        TinyJuiceHost::Codex => serde_json::to_string_pretty(&serde_json::json!({
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": format!("{binary} codex-post-tool-use"),
+                                "statusMessage": CODEX_HOOK_STATUS,
+                                "timeout": 10
+                            }
+                        ]
+                    }
+                ]
+            }
+        }))
+        .expect("template JSON serializes"),
+        TinyJuiceHost::ClaudeCode => serde_json::to_string_pretty(&serde_json::json!({
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": format!("{binary} claude-code-post-tool-use"),
+                                "statusMessage": CLAUDE_CODE_HOOK_STATUS,
+                                "timeout": 10
+                            }
+                        ]
+                    }
+                ]
+            }
+        }))
+        .expect("template JSON serializes"),
+        TinyJuiceHost::OpenHuman | TinyJuiceHost::RustHarness => {
+            format!(
+                r#"use tinyjuice::{{AgentTokenjuiceCompression, TinyJuiceHost, TinyJuiceSdk, ToolExecutionInput}};
+
+let sdk = TinyJuiceSdk::new(TinyJuiceHost::{variant})
+    .with_profile(AgentTokenjuiceCompression::Full);
+let response = sdk.compress_tool_output(ToolExecutionInput {{
+    tool_name: "shell".to_string(),
+    command: Some("cargo test".to_string()),
+    combined_text: Some(tool_output),
+    exit_code: Some(exit_code),
+    ..Default::default()
+}}).await;
+"#,
+                variant = match host {
+                    TinyJuiceHost::OpenHuman => "OpenHuman",
+                    TinyJuiceHost::RustHarness => "RustHarness",
+                    _ => unreachable!(),
+                }
+            )
+        }
+        TinyJuiceHost::GenericJson => serde_json::to_string_pretty(&serde_json::json!({
+            "host": "generic-json",
+            "profile": "full",
+            "input": {
+                "toolName": "shell",
+                "command": "cargo test",
+                "argv": ["cargo", "test"],
+                "combinedText": "tool output goes here",
+                "exitCode": 0,
+                "metadata": {
+                    "source": "custom-harness"
+                }
+            },
+            "options": {
+                "minBytesToCompress": 512,
+                "maxInlineChars": 1200,
+                "ccrEnabled": true
+            }
+        }))
+        .expect("template JSON serializes"),
+    }
+}
+
+fn response_from_output(
+    host: TinyJuiceHost,
+    profile: AgentTokenjuiceCompression,
+    original_text: &str,
+    output: CompressedOutput,
+) -> SdkCompressionResponse {
+    let raw_chars = original_text.chars().count();
+    let reduced_chars = output.text.chars().count();
+    let ratio = if raw_chars == 0 {
+        1.0
+    } else {
+        reduced_chars as f64 / raw_chars as f64
+    };
+    let original_tokens = estimate_tokens(original_text) as usize;
+    let compacted_tokens = estimate_tokens(&output.text) as usize;
+    let family = output.content_kind.as_str().to_string();
+    let compressor = output.compressor.as_str().to_string();
+    SdkCompressionResponse {
+        inline_text: output.text,
+        preview_text: None,
+        stats: SdkCompressionStats {
+            raw_chars,
+            reduced_chars,
+            ratio,
+            original_bytes: output.original_bytes,
+            compacted_bytes: output.compacted_bytes,
+            original_tokens,
+            compacted_tokens,
+        },
+        classification: SdkCompressionClassification {
+            family,
+            content_kind: output.content_kind.as_str().to_string(),
+            compressor: compressor.clone(),
+            confidence: if output.applied { 1.0 } else { 0.0 },
+            matched_reducer: output.applied.then_some(compressor),
+        },
+        host,
+        profile,
+        applied: output.applied,
+        lossy: output.lossy,
+        ccr_token: output.ccr_token,
+    }
+}
+
+fn decorate_hook_inline_text(response: &SdkCompressionResponse) -> String {
+    let Some(token) = &response.ccr_token else {
+        return response.inline_text.clone();
+    };
+    format!(
+        "{}\n\n[CLI recovery: run `tinyjuice retrieve {}` to print the full original.]",
+        response.inline_text, token
+    )
+}
+
+fn tool_output_text(input: &ToolExecutionInput) -> String {
+    if let Some(text) = &input.combined_text {
+        return text.clone();
+    }
+    match (&input.stdout, &input.stderr) {
+        (Some(stdout), Some(stderr)) if !stderr.is_empty() => format!("{stdout}\n{stderr}"),
+        (Some(stdout), _) => stdout.clone(),
+        (_, Some(stderr)) => stderr.clone(),
+        _ => String::new(),
+    }
+}
+
+fn is_supported_post_tool_payload(host: TinyJuiceHost, value: &Value) -> bool {
+    let event = string_field(value, &["hook_event_name", "hookEventName"]);
+    if event.as_deref() != Some("PostToolUse") {
+        return false;
+    }
+    let Some(tool_name) = string_field(value, &["tool_name", "toolName"]) else {
+        return false;
+    };
+    match host {
+        TinyJuiceHost::Codex | TinyJuiceHost::ClaudeCode => {
+            matches!(tool_name.as_str(), "Bash" | "bash" | "shell" | "exec")
+        }
+        TinyJuiceHost::GenericJson | TinyJuiceHost::OpenHuman | TinyJuiceHost::RustHarness => true,
+    }
+}
+
+fn hint_from_tool_input(input: &ToolExecutionInput) -> ContentHint {
+    ContentHint {
+        source_tool: (!input.tool_name.is_empty()).then(|| input.tool_name.clone()),
+        extension: extension_from_args(input.args.as_ref()),
+        query: query_from_args(input.args.as_ref()),
+        ..Default::default()
+    }
+}
+
+fn extension_from_args(args: Option<&HashMap<String, Value>>) -> Option<String> {
+    let path = args.and_then(|map| {
+        ["path", "file_path", "file", "filename"]
+            .iter()
+            .find_map(|key| map.get(*key).and_then(Value::as_str))
+    })?;
+    std::path::Path::new(path)
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(str::to_ascii_lowercase)
+}
+
+fn query_from_args(args: Option<&HashMap<String, Value>>) -> Option<String> {
+    args.and_then(|map| {
+        ["query", "pattern", "search", "q", "regex"]
+            .iter()
+            .find_map(|key| map.get(*key).and_then(Value::as_str))
+            .map(str::to_string)
+    })
+}
+
+/// Convert either the full SDK request shape or a bare ToolExecutionInput JSON
+/// object into a request.
+pub fn request_from_json_value(value: Value) -> Result<SdkCompressionRequest, serde_json::Error> {
+    if value.get("input").is_some() {
+        serde_json::from_value(value)
+    } else if looks_like_host_hook_payload(&value) {
+        Ok(request_from_host_hook_payload(value))
+    } else {
+        let input = serde_json::from_value(value)?;
+        Ok(SdkCompressionRequest::new(input))
+    }
+}
+
+fn looks_like_host_hook_payload(value: &Value) -> bool {
+    value.get("tool_name").is_some()
+        || value.get("tool_input").is_some()
+        || value.get("tool_response").is_some()
+        || value.get("toolInput").is_some()
+        || value.get("toolResponse").is_some()
+}
+
+fn request_from_host_hook_payload(value: Value) -> SdkCompressionRequest {
+    let tool_name = string_field(&value, &["tool_name", "toolName"]).unwrap_or_default();
+    let tool_input = value
+        .get("tool_input")
+        .or_else(|| value.get("toolInput"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let tool_response = value
+        .get("tool_response")
+        .or_else(|| value.get("toolResponse"))
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    let command = string_field(&tool_input, &["command", "cmd"]);
+    let argv = array_string_field(&tool_input, &["argv"]);
+    let args = object_as_hash_map(tool_input.as_object());
+    let combined_text = response_text(&tool_response);
+    let exit_code = i32_field(&value, &["exitCode", "exit_code"]).or_else(|| {
+        i32_field(
+            &tool_response,
+            &["exitCode", "exit_code", "status", "statusCode"],
+        )
+    });
+    let cwd = string_field(&value, &["cwd"])
+        .or_else(|| string_field(&tool_input, &["cwd"]))
+        .or_else(|| string_field(&tool_response, &["cwd"]));
+
+    SdkCompressionRequest::new(ToolExecutionInput {
+        tool_name,
+        command,
+        argv,
+        args,
+        cwd,
+        combined_text,
+        exit_code,
+        ..Default::default()
+    })
+}
+
+fn string_field(value: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_str))
+        .map(str::to_string)
+}
+
+fn i32_field(value: &Value, keys: &[&str]) -> Option<i32> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_i64))
+        .and_then(|value| i32::try_from(value).ok())
+}
+
+fn array_string_field(value: &Value, keys: &[&str]) -> Option<Vec<String>> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_array))
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .filter(|items| !items.is_empty())
+}
+
+fn object_as_hash_map(object: Option<&Map<String, Value>>) -> Option<HashMap<String, Value>> {
+    let map = object?;
+    let converted = map
+        .iter()
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect::<HashMap<_, _>>();
+    (!converted.is_empty()).then_some(converted)
+}
+
+fn response_text(value: &Value) -> Option<String> {
+    if let Some(text) = value.as_str() {
+        return Some(text.to_string());
+    }
+    string_field(
+        value,
+        &[
+            "combinedText",
+            "combined_text",
+            "output",
+            "text",
+            "content",
+            "stdout",
+            "stderr",
+        ],
+    )
+    .or_else(|| {
+        if value.is_null() {
+            None
+        } else {
+            Some(value.to_string())
+        }
+    })
+}
+
+/// Build a JSON object with command/argv fields suitable for hosts that still
+/// use [`crate::compact_tool_output_with_policy`].
+pub fn arguments_value(input: &ToolExecutionInput) -> Option<Value> {
+    let mut map = Map::new();
+    if let Some(args) = &input.args {
+        for (key, value) in args {
+            map.insert(key.clone(), value.clone());
+        }
+    }
+    if let Some(command) = &input.command {
+        map.insert("command".to_string(), Value::String(command.clone()));
+    }
+    if let Some(argv) = &input.argv {
+        map.insert(
+            "argv".to_string(),
+            Value::Array(argv.iter().cloned().map(Value::String).collect()),
+        );
+    }
+    (!map.is_empty()).then_some(Value::Object(map))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn sdk_compacts_command_output() {
+        let mut lines = vec!["On branch main".to_string()];
+        for index in 0..200 {
+            lines.push(format!("\tmodified:   src/file_{index}.rs"));
+        }
+        let response = compress_request(SdkCompressionRequest {
+            host: TinyJuiceHost::GenericJson,
+            profile: AgentTokenjuiceCompression::Full,
+            input: ToolExecutionInput {
+                tool_name: "shell".to_string(),
+                command: Some("git status".to_string()),
+                combined_text: Some(lines.join("\n")),
+                exit_code: Some(0),
+                ..Default::default()
+            },
+            options: SdkCompressOptions {
+                min_bytes_to_compress: Some(64),
+                ..Default::default()
+            },
+        })
+        .await;
+
+        assert!(response.applied, "response: {response:?}");
+        assert_eq!(response.host, TinyJuiceHost::GenericJson);
+        assert_eq!(response.classification.content_kind, "plain_text");
+        assert!(response.stats.reduced_chars < response.stats.raw_chars);
+    }
+
+    #[test]
+    fn parses_bare_tool_input_payload() {
+        let request = request_from_json_value(json!({
+            "toolName": "shell",
+            "command": "cargo test",
+            "combinedText": "ok"
+        }))
+        .expect("request");
+        assert_eq!(request.input.tool_name, "shell");
+        assert_eq!(request.input.command.as_deref(), Some("cargo test"));
+    }
+
+    #[test]
+    fn parses_codex_style_hook_payload() {
+        let request = request_from_json_value(json!({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "shell",
+            "tool_input": {
+                "command": "cargo test",
+                "cwd": "/repo"
+            },
+            "tool_response": {
+                "output": "test output",
+                "exitCode": 0
+            }
+        }))
+        .expect("request");
+        assert_eq!(request.input.tool_name, "shell");
+        assert_eq!(request.input.command.as_deref(), Some("cargo test"));
+        assert_eq!(request.input.cwd.as_deref(), Some("/repo"));
+        assert_eq!(request.input.combined_text.as_deref(), Some("test output"));
+        assert_eq!(request.input.exit_code, Some(0));
+    }
+
+    #[test]
+    fn renders_hook_templates_as_json() {
+        let codex =
+            serde_json::from_str::<Value>(&host_template(TinyJuiceHost::Codex, "tinyjuice"))
+                .expect("codex template");
+        assert_eq!(
+            codex["hooks"]["PostToolUse"][0]["matcher"].as_str(),
+            Some("Bash")
+        );
+        assert!(
+            codex["hooks"]["PostToolUse"][0]["hooks"][0]["command"]
+                .as_str()
+                .expect("command")
+                .contains("codex-post-tool-use")
+        );
+
+        let claude =
+            serde_json::from_str::<Value>(&host_template(TinyJuiceHost::ClaudeCode, "tinyjuice"))
+                .expect("claude template");
+        assert!(
+            claude["hooks"]["PostToolUse"][0]["hooks"][0]["command"]
+                .as_str()
+                .expect("command")
+                .contains("claude-code-post-tool-use")
+        );
+    }
+
+    #[tokio::test]
+    async fn codex_hook_response_adds_context() {
+        let mut lines = vec!["On branch main".to_string()];
+        for index in 0..200 {
+            lines.push(format!("\tmodified:   src/file_{index}.rs"));
+        }
+        let payload = json!({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "git status"},
+            "tool_response": {"output": lines.join("\n"), "exitCode": 0}
+        });
+        let response = compress_host_hook_payload(
+            TinyJuiceHost::Codex,
+            &payload.to_string(),
+            SdkCompressOptions {
+                min_bytes_to_compress: Some(64),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("hook response")
+        .expect("compressed");
+        assert_eq!(
+            response["hookSpecificOutput"]["hookEventName"].as_str(),
+            Some("PostToolUse")
+        );
+        assert!(
+            response["hookSpecificOutput"]["additionalContext"]
+                .as_str()
+                .expect("context")
+                .contains("M: src/file_")
+        );
+    }
+
+    #[tokio::test]
+    async fn claude_hook_response_updates_tool_output() {
+        let mut lines = vec!["On branch main".to_string()];
+        for index in 0..200 {
+            lines.push(format!("\tmodified:   src/file_{index}.rs"));
+        }
+        let payload = json!({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "git status"},
+            "tool_response": {"output": lines.join("\n"), "exitCode": 0}
+        });
+        let response = compress_host_hook_payload(
+            TinyJuiceHost::ClaudeCode,
+            &payload.to_string(),
+            SdkCompressOptions {
+                min_bytes_to_compress: Some(64),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("hook response")
+        .expect("compressed");
+        assert!(
+            response["hookSpecificOutput"]["updatedToolOutput"]
+                .as_str()
+                .expect("output")
+                .contains("M: src/file_")
+        );
+    }
+
+    #[tokio::test]
+    async fn hook_response_skips_non_matching_event() {
+        let payload = json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "git status"}
+        });
+        let response = compress_host_hook_payload(
+            TinyJuiceHost::Codex,
+            &payload.to_string(),
+            SdkCompressOptions::default(),
+        )
+        .await
+        .expect("hook response");
+        assert!(response.is_none());
+    }
+
+    #[test]
+    fn host_ids_are_parseable() {
+        for spec in host_install_specs() {
+            let serialized = serde_json::to_value(spec.host).expect("host serializes");
+            assert_eq!(serialized, Value::String(spec.host.id().to_string()));
+            let parsed = TinyJuiceHost::from_str(spec.host.id()).expect("host id");
+            assert_eq!(parsed, spec.host);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the first installable TinyJuice SDK and host integration surface for Codex, Claude Code, and generic harnesses.

- Bumps the crate/package version to `0.2.0`.
- Adds a host-neutral SDK module with serializable request/response types, host metadata, hook templates, and Codex/Claude hook response shaping.
- Adds a `tinyjuice` binary with `reduce-json`, `hosts`, `host-template`, `install`, `codex-post-tool-use`, `claude-code-post-tool-use`, and `retrieve` commands.
- Installs Codex and Claude Code hooks by merging into existing JSON config and writing backups.
- Uses disk-backed CCR for CLI hook processes so recovery tokens survive after the short-lived hook exits.
- Updates the README with SDK, JSON protocol, Codex, and Claude Code usage.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- Temp install smoke for `tinyjuice install codex` and `tinyjuice install claude-code`
- Hook-output smoke for `tinyjuice codex-post-tool-use` and `tinyjuice claude-code-post-tool-use`
- Cross-process `tinyjuice retrieve <token>` smoke for disk-backed CCR recovery