### PR TITLE
fix(release): tolerate missing crates token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,6 +378,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Publish crate after module release succeeds
-        run: cargo publish --locked --package tinyjuice
+        run: |
+          if [[ -z "$CARGO_REGISTRY_TOKEN" ]]; then
+            echo "::notice::CARGO_REGISTRY_TOKEN is not configured; skipping crates.io compatibility publish"
+            exit 0
+          fi
+          cargo publish --locked --package tinyjuice
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- keep the native module release authoritative when crates.io credentials are not configured
- emit an explicit workflow notice and skip only the compatibility crate publish

## API Or Behavior Changes

None. This only prevents an absent optional repository secret from making an otherwise verified module release red.

## Tests

- [x] failure reproduced in release run 31740361029 (`please provide a non-empty token`)
- [x] shell guard uses the same `CARGO_REGISTRY_TOKEN` environment consumed by Cargo

## Documentation

No documentation change; workflow-only fix.