### PR TITLE
feat(bus): add FromStr beside as_str for the flattened enums

### DIFF
--- a/crates/tinyjuice-bus/src/test.rs
+++ b/crates/tinyjuice-bus/src/test.rs
@@ -78,3 +78,49 @@ fn compress_options_round_trip_through_their_defaults() {
         serde_json::to_value(&defaults).unwrap()
     );
 }
+
+/// Every variant survives `as_str` and back.
+///
+/// The two directions are what `Compact` needs: it flattens both enums to their
+/// `as_str` spelling on the way out, and a caller parses that back. A variant
+/// added to one table and not the other is a value that arrives and cannot be
+/// read, so the round trip is checked over the whole set rather than a sample.
+#[test]
+fn the_flattened_spellings_round_trip_for_every_variant() {
+    use std::str::FromStr as _;
+
+    for kind in [
+        ContentKind::Json,
+        ContentKind::Code,
+        ContentKind::Log,
+        ContentKind::Search,
+        ContentKind::Diff,
+        ContentKind::Html,
+        ContentKind::PlainText,
+    ] {
+        assert_eq!(ContentKind::from_str(kind.as_str()).unwrap(), kind);
+    }
+
+    for compressor in [
+        CompressorKind::SmartCrusher,
+        CompressorKind::Code,
+        CompressorKind::Log,
+        CompressorKind::Search,
+        CompressorKind::Diff,
+        CompressorKind::Html,
+        CompressorKind::MlText,
+        CompressorKind::Generic,
+        CompressorKind::None,
+    ] {
+        assert_eq!(
+            CompressorKind::from_str(compressor.as_str()).unwrap(),
+            compressor
+        );
+    }
+
+    // The flattened spelling is deliberately not the serde one. `plain_text`
+    // parses; `plainText` does not, and a host that mixed the two would get a
+    // silent `PlainText` fallback on every response.
+    assert!(ContentKind::from_str("plainText").is_err());
+    assert!(CompressorKind::from_str("smartCrusher").is_err());
+}

--- a/crates/tinyjuice-bus/src/types.rs
+++ b/crates/tinyjuice-bus/src/types.rs
@@ -83,6 +83,32 @@ impl ContentKind {
     }
 }
 
+impl std::str::FromStr for ContentKind {
+    type Err = ();
+
+    /// The exact inverse of [`as_str`](Self::as_str).
+    ///
+    /// This is contract surface rather than a convenience: `Compact` answers
+    /// with [`CompactResponse`](crate::wire::CompactResponse), which flattens
+    /// the kind to its `as_str` spelling, so a caller that wants the enum back
+    /// has to parse that string. Without the inverse living beside the forward
+    /// direction, every host writes the table itself and one of them gets a
+    /// spelling wrong — `plain_text` here is not the `plainText` that serde
+    /// produces, and nothing but this pairing says so.
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(match value {
+            "json" => Self::Json,
+            "code" => Self::Code,
+            "log" => Self::Log,
+            "search" => Self::Search,
+            "diff" => Self::Diff,
+            "html" => Self::Html,
+            "plain_text" => Self::PlainText,
+            _ => return Err(()),
+        })
+    }
+}
+
 /// A caller-supplied prior about a blob's content, so the detector doesn't have
 /// to work from scratch. Any field may be `None`; the detector resolves what it
 /// can and falls back to structural heuristics. An `explicit` kind is a hard
@@ -152,6 +178,28 @@ impl CompressorKind {
             CompressorKind::Generic => "generic",
             CompressorKind::None => "none",
         }
+    }
+}
+
+impl std::str::FromStr for CompressorKind {
+    type Err = ();
+
+    /// The exact inverse of [`as_str`](Self::as_str), for the same reason
+    /// [`ContentKind`]'s exists: `Compact` reports the compressor as that
+    /// spelling, not as the `smartCrusher` serde emits.
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(match value {
+            "smartcrusher" => Self::SmartCrusher,
+            "code" => Self::Code,
+            "log" => Self::Log,
+            "search" => Self::Search,
+            "diff" => Self::Diff,
+            "html" => Self::Html,
+            "ml_text" => Self::MlText,
+            "generic" => Self::Generic,
+            "none" => Self::None,
+            _ => return Err(()),
+        })
     }
 }
 


### PR DESCRIPTION
## What

`ContentKind` and `CompressorKind` gain `FromStr`, the exact inverse of the `as_str` they already have, with a test that round-trips every variant.

## Why

`Compact` answers with `CompactResponse`, which **flattens both enums to their `as_str` spelling** rather than carrying them as typed fields. A caller that wants the enum back has to parse that string, so the inverse is contract surface, not a convenience — and it cannot live on the caller's side, because `FromStr` for a foreign type is an orphan-rule error. Splitting the contract out therefore made a host that previously had both directions have only one: this is exactly the break OpenHuman hit adopting `tinyjuice-bus`.

The pairing matters more than it looks. The flattened spelling is deliberately **not** the serde one:

| Variant | serde | `as_str` / `FromStr` |
| --- | --- | --- |
| `ContentKind::PlainText` | `plainText` | `plain_text` |
| `CompressorKind::SmartCrusher` | `smartCrusher` | `smartcrusher` |

Nothing but the two functions sitting together says so. With only the forward direction in the crate, every host writes the table itself, and a host that reached for the serde spelling gets a silent `PlainText` / `None` fallback on every response — wrong stats, no error.

## Verification

`cargo test -p tinyjuice-bus` — 6 passed. The new test walks all 7 + 9 variants rather than a sample, so a variant added to one table and not the other fails, and it asserts the serde spellings are rejected.